### PR TITLE
Clean typo

### DIFF
--- a/create-a-command-line-program/includes/7-list-task-function.md
+++ b/create-a-command-line-program/includes/7-list-task-function.md
@@ -39,7 +39,7 @@ use std::fmt;
 impl fmt::Display for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let created_at = self.created_at.with_timezone(&Local).format("%F %H:%M");
-        write!(f, )"{:<50} [{}]", self.text, created_at)
+        write!(f, "{:<50} [{}]", self.text, created_at)
     }
 }
 ```


### PR DESCRIPTION
There was an extra parenthesis in the `write!` macro.