### PR TITLE
Use reference symbol in longest_word function

### DIFF
--- a/ownership-borrowing-lifetimes/includes/3-validate-references-with-lifetimes.md
+++ b/ownership-borrowing-lifetimes/includes/3-validate-references-with-lifetimes.md
@@ -70,7 +70,7 @@ fn main() {
     let magic1 = String::from("abracadabra!");
     let magic2 = String::from("shazam!");
 
-    let result = longest_word(magic1, magic2);
+    let result = longest_word(&magic1, &magic2);
     println!("The longest magic word is {}", result);
 }
 
@@ -131,7 +131,7 @@ fn main() {
     let result;
     {
         let magic2 = String::from("shazam!");
-        result = longest_word(magic1, magic2);
+        result = longest_word(&magic1, &magic2);
     }
     println!("The longest magic word is {}", result);
 }


### PR DESCRIPTION
@tilacog could I get your thoughts on this change please!

I got some feedback that this unit should use the reference symbol for the two variables passed to the `longest_word` function. I see that when you first introduce this example, it is expected to fail, but I believe that is because of the "missing lifetime specifier" in the function declaration.

It looks like the same change should also be made in line 134 since the following error specifies "borrowed value does not live long enough" and not a mismatch of types.

Let me know if you agree with these changes. Thanks!