### PR TITLE
Fix unclosed delimiter

### DIFF
--- a/modules-packages-crates/includes/2-split-code-into-modules.md
+++ b/modules-packages-crates/includes/2-split-code-into-modules.md
@@ -17,6 +17,7 @@ mod authentication {
                 username: username.to_string(),
                 password_hash: hash_password(password),
             }
+        }
     }
     fn hash_password(input: &str) -> u64 { /*...*/ }
 }


### PR DESCRIPTION
Function `User::new` is missing a closing braces.